### PR TITLE
Netcdf qinit

### DIFF
--- a/RAPIDpy/helper_functions.py
+++ b/RAPIDpy/helper_functions.py
@@ -6,6 +6,7 @@
     Created by Alan D Snow, 2015.
 """
 import csv
+import netCDF4 as nc
 from os import remove
 from sys import version_info
 
@@ -68,6 +69,14 @@ def csv_to_list(csv_file, delimiter=','):
         else:
             reader = csv.reader(csv_con, delimiter=delimiter)
         return list(reader)
+
+def netcdf_to_list(netcdf_file):
+    """
+    Reads in a netCDF file and returns the contents as list
+    """
+    with nc.Dataset(netcdf_file, 'r') as nc_con:
+        netcdf_list = [[i] for i in nc_con['Qout'][0][:]]
+        return netcdf_list
 
 
 def compare_csv_decimal_files(file1, file2, header=True, timeseries=False):

--- a/RAPIDpy/inflow/lsm_rapid_process.py
+++ b/RAPIDpy/inflow/lsm_rapid_process.py
@@ -53,7 +53,7 @@ def generate_inflows_from_runoff(args):
     mp_lock = args[6]
     steps_per_file = args[7]
     convert_one_hour_to_three = args[8]
-    
+
     time_start_all = datetime.utcnow()
 
     if not isinstance(runoff_file_list, list):
@@ -680,7 +680,7 @@ def run_lsm_rapid_process(rapid_executable_location,
         Various defaults used by each model.
     initial_flows_file: str, optional
         If given, this is the path to a file with initial flows
-        for the simulaion.
+        for the simulation.
     ensemble_list: list, optional
         This is the expexted ensemble name appended to the end of the
         file name.
@@ -858,7 +858,7 @@ def run_lsm_rapid_process(rapid_executable_location,
 
         # IDENTIFY THE GRID
         lsm_file_data = identify_lsm_grid(lsm_file_list[0])
- 
+
         # load in the datetime pattern
         if file_datetime_pattern is None or file_datetime_re_pattern is None:
             file_datetime_re_pattern = \
@@ -902,7 +902,7 @@ def run_lsm_rapid_process(rapid_executable_location,
         file_time_hours = time_step / 3600.0
         file_time_divisible_by_three = (steps_per_file % 3 == 0)
         convert_one_hour_to_three_within_file = False
-        
+
         # VALIDATING INPUT IF DIVIDING BY 3
         if convert_one_hour_to_three:
             if (lsm_file_data['grid_type'] in ('nldas', 'lis', 'joules')):
@@ -916,19 +916,19 @@ def run_lsm_rapid_process(rapid_executable_location,
                 time_step *= 3
             elif file_timestep_is_hourly and file_time_divisible_by_three:
                 # MPG: The above code handles the case where each file contains
-                # values for a single hourly timestep. We must also consider 
+                # values for a single hourly timestep. We must also consider
                 # the case where files contain multiple timesteps.
                 convert_one_hour_to_three_within_file = True
                 total_num_time_steps /= 3
                 time_step *= 3
             elif not file_timestep_is_hourly:
                 raise ValueError(
-                    "{0} data has timestep of {1} hour(s). " 
-                    .format(lsm_file_data['model_name'], file_time_hours) + 
+                    "{0} data has timestep of {1} hour(s). "
+                    .format(lsm_file_data['model_name'], file_time_hours) +
                     "Cannot perform conversion to three-hourly timestep")
             elif not file_time_divisible_by_three:
                 raise ValueError(
-                    "{0} files contain {1} hour(s) of data. " 
+                    "{0} files contain {1} hour(s) of data. "
                     .format(lsm_file_data['model_name'], file_time_hours) +
                     "Cannot perform conversion to three-hourly timestep")
             else:
@@ -1130,7 +1130,7 @@ def run_lsm_rapid_process(rapid_executable_location,
                         lsm_rapid_output_file:
                     seasonal_qinit_file = os.path.join(
                         master_watershed_input_directory,
-                        'seasonal_qinit_{0}.csv'.format(out_file_ending[:-3]))
+                        'seasonal_qinit_{0}.nc'.format(out_file_ending[:-3]))
                     rapid_manager.generate_seasonal_intitialization(
                         seasonal_qinit_file)
 

--- a/RAPIDpy/postprocess/merge.py
+++ b/RAPIDpy/postprocess/merge.py
@@ -64,7 +64,7 @@ from pytz import utc
 # local
 from ..dataset import RAPIDDataset
 from ..helper_functions import (add_latlon_metadata, csv_to_list,
-                                remove_files, log)
+                                netcdf_to_list, remove_files, log)
 
 
 class ConvertRAPIDOutputToCF(object):
@@ -477,7 +477,10 @@ class ConvertRAPIDOutputToCF(object):
             lookup_comids = np.array([int(float(row[0])) for row
                                       in lookup_table])
 
-            init_flow_table = csv_to_list(self.qinit_file)
+            if self.qinit_file.endswith(".csv"):
+                init_flow_table = csv_to_list(self.qinit_file)
+            else:
+                init_flow_table = netcdf_to_list(self.qinit_file)
 
             for index, comid in enumerate(
                     self.cf_nc.variables[self.output_id_dim_name][:]):

--- a/RAPIDpy/rapid.py
+++ b/RAPIDpy/rapid.py
@@ -17,6 +17,7 @@ from time import gmtime
 from dateutil.parser import parse
 import numpy as np
 from requests import get
+import netCDF4 as nc
 import xarray
 
 from .dataset import RAPIDDataset
@@ -870,9 +871,16 @@ class RAPID(object):
 
         log("Writing to file ...",
             "INFO")
-        with open_csv(qinit_file, 'w') as qinit_out:
-            for init_flow in init_flows_array:
-                qinit_out.write('{0}\n'.format(init_flow))
+        if qinit_file.endswith(".csv"):
+            with open_csv(qinit_file, 'w') as qinit_out:
+                for init_flow in init_flows_array:
+                    qinit_out.write('{0}\n'.format(init_flow))
+        else:
+            with nc.Dataset(qinit_file, "w", format="NETCDF3_CLASSIC") as qinit_out:
+                qinit_out.createDimension('Time', 1)
+                qinit_out.createDimension('rivid', stream_id_array.size)
+                var_Qout = qinit_out.createVariable('Qout', 'f8', ('Time', 'rivid',))
+                var_Qout[:] = init_flows_array
 
         self.Qinit_file = qinit_file
         self.BS_opt_Qinit = True

--- a/RAPIDpy/rapid.py
+++ b/RAPIDpy/rapid.py
@@ -989,9 +989,16 @@ class RAPID(object):
 
             log("Writing to file ...",
                 "INFO")
-            with open_csv(qinit_file, 'w') as qinit_out:
-                for init_flow in init_flows_array:
-                    qinit_out.write('{}\n'.format(init_flow))
+            if qinit_file.endswith(".csv"):
+                with open_csv(qinit_file, 'w') as qinit_out:
+                    for init_flow in init_flows_array:
+                        qinit_out.write('{}\n'.format(init_flow))
+            else:
+                with nc.Dataset(qinit_file, "w", format="NETCDF3_CLASSIC") as qinit_out:
+                    qinit_out.createDimension('Time', 1)
+                    qinit_out.createDimension('rivid', stream_id_array.size)
+                    var_Qout = qinit_out.createVariable('Qout', 'f8', ('Time', 'rivid',))
+                    var_Qout[:] = init_flows_array
 
             log("Initialization Complete!",
                 "INFO")

--- a/RAPIDpy/rapid.py
+++ b/RAPIDpy/rapid.py
@@ -734,6 +734,8 @@ class RAPID(object):
         if not rapid_namelist_file or not os.path.exists(rapid_namelist_file):
             # generate input file if it does not exist
             self.generate_namelist_file(temp_rapid_namelist_file)
+            with open(temp_rapid_namelist_file, 'r') as file_:
+                log(file_.read(), "INFO")
         else:
             # update existing file
             self.update_namelist_file(rapid_namelist_file,

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='RAPIDpy',
-    version='2.6.0',
+    version='2.7.0',
     description='Python interface for RAPID (rapid-hub.org)',
     long_description='RAPIDpy is a python interface for RAPID that assists '
          'to prepare inputs, runs the RAPID program, and provides '


### PR DESCRIPTION
Updated RAPIDpy to use and ouput qinit files as netcdf. RAPID switched a long time ago and does not accept csv files anymore.

This restores RAPIDpy's ability to assimilate and generate qinit files through RAPIDpy